### PR TITLE
Fix all-days print preview showing only first page in Chrome

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -621,6 +621,7 @@ body.day-page {
         box-shadow: none;
         border-radius: 0;
         background: white;
+        backdrop-filter: none;
     }
 
     .page-header {


### PR DESCRIPTION
Disable backdrop-filter in @media print on .daily-office elements. With 365 days on the page, each backdrop-filter creates a GPU compositing layer, causing Chrome's print renderer to choke after the first one.